### PR TITLE
Disable radiobuttons on product bundles pages

### DIFF
--- a/wc-variations-radio-buttons.php
+++ b/wc-variations-radio-buttons.php
@@ -80,8 +80,11 @@ if ( is_plugin_active( 'woocommerce/woocommerce.php') ) {
 		}
 
 		function load_scripts() {
-			wp_deregister_script( 'wc-add-to-cart-variation' );
-			wp_register_script( 'wc-add-to-cart-variation', $this->get_plugin_url() . 'assets/js/frontend/add-to-cart-variation.js', array( 'jquery', 'wp-util' ), self::VERSION );
+			// Don't load JS if current product type is bundle to prevent the page from not working
+			if (!(wc_get_product() && wc_get_product()->is_type('bundle'))) {
+				wp_deregister_script( 'wc-add-to-cart-variation' );
+				wp_register_script( 'wc-add-to-cart-variation', $this->get_plugin_url() . 'assets/js/frontend/add-to-cart-variation.js', array( 'jquery', 'wp-util' ), self::VERSION );
+			}
 		}
 	}
 


### PR DESCRIPTION
This plugin is not compatible with the product type bundle. Instead of breaking the standard functionality we disable the plugins Javascript if we are on a product page with the type bundle.